### PR TITLE
Bug fix: fix `keyword_pattern` with a better regex

### DIFF
--- a/lua/cmp-env/init.lua
+++ b/lua/cmp-env/init.lua
@@ -9,7 +9,7 @@ source.get_trigger_characters = function()
 end
 
 source.get_keyword_pattern = function()
-	return [[\$]]
+	return "\\$[^[:blank:]]"
 end
 
 source.complete = require("cmp-env.complete")


### PR DESCRIPTION
The original `get_keyword_pattern` stops if you try to type after the dollar sign. This one should work without problems.