### PR TITLE
`complete.lua`: general improvements to code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ cmp.setup({
         {
             name = "env",
             option = {
+                eval_on_confirm = false,
                 show_documentation_window = true,
                 item_kind = cmp.lsp.CompletionItemKind.Variable
             },
@@ -33,6 +34,14 @@ cmp.setup({
     },
 })
 ```
+
+### eval_on_confirm (type: boolean)
+
+_Default:_ `false`
+
+Specify whether a confirmed entry should insert the evaluated environment
+variable rather than the environment variable itself. For example, if you
+confirm `$SHELL`, it might insert `/bin/bash`.
 
 ### show_documentation_window (type: boolean)
 

--- a/lua/cmp-env/complete.lua
+++ b/lua/cmp-env/complete.lua
@@ -8,7 +8,7 @@ local completion_items = {}
 local function setup_documentation_for_item(key, value)
 	return {
 		kind = "markdown",
-		value = "```sh\n" .. key .. "\n\n" .. value .. "\n```",
+		value = "```sh\n" .. value .. "\n```",
 	}
 end
 
@@ -36,17 +36,18 @@ local function setup_completion_items(params)
 		-- If show_documentation_window is set to false,
 		-- do not add documentation table inside completion_items
 		if opts.show_documentation_window == false then
-			table.insert(completion_items, {
-				label = key,
-				kind = item_kind,
-			})
+			documentation = nil
 		else
-			table.insert(completion_items, {
-				label = key,
-				documentation = setup_documentation_for_item(key, value),
-				kind = item_kind,
-			})
+			documentation = setup_documentation_for_item(key, value)
 		end
+
+		table.insert(completion_items, {
+			label = key,
+			insertText = value,
+			word = key,
+			documentation = documentation,
+			kind = item_kind,
+		})
 	end
 end
 

--- a/lua/cmp-env/complete.lua
+++ b/lua/cmp-env/complete.lua
@@ -35,15 +35,22 @@ local function setup_completion_items(params)
 
 		-- If show_documentation_window is set to false,
 		-- do not add documentation table inside completion_items
-		if opts.show_documentation_window == false then
-			documentation = nil
-		else
+		if opts.show_documentation_window then
 			documentation = setup_documentation_for_item(key, value)
+		else
+			documentation = nil
+		end
+		-- If eval_on_confirm is set to true,
+		-- use `value` instead of `key` upon completion
+		if opts.eval_on_confirm then
+			insertText = value
+		else
+			insertText = key
 		end
 
 		table.insert(completion_items, {
 			label = key,
-			insertText = value,
+			insertText = insertText,
 			word = key,
 			documentation = documentation,
 			kind = item_kind,

--- a/lua/cmp-env/options.lua
+++ b/lua/cmp-env/options.lua
@@ -3,6 +3,7 @@ local cmp = require("cmp")
 local M = {}
 
 M.default_options = {
+	eval_on_confirm = false,
 	show_documentation_window = true,
 	item_kind = cmp.lsp.CompletionItemKind.Variable,
 }
@@ -10,6 +11,7 @@ M.default_options = {
 M.validate_options = function(params)
 	local options = vim.tbl_deep_extend("keep", params.option, M.default_options)
 	vim.validate({
+		eval_on_confirm = { options.eval_on_confirm, "boolean" },
 		show_documentation_window = { options.show_documentation_window, "boolean" },
 		item_kind = { options.item_kind, "number" },
 	})


### PR DESCRIPTION
1. Do not show key in the documentation window because it is redundant
2. Avoid repetitively calling `table.insert` twice
3. Insert the value of the environment variable if the user confirms
   * If the user selects instead of confirms, do not insert the value of the evironment variable