### PR TITLE
Insert completion item options more efficiently

### DIFF
--- a/lua/cmp-env/complete.lua
+++ b/lua/cmp-env/complete.lua
@@ -33,26 +33,14 @@ local function setup_completion_items(params)
 		-- eg. PATH -> $PATH
 		key = "$" .. key
 
-		-- If show_documentation_window is set to false,
-		-- do not add documentation table inside completion_items
-		if opts.show_documentation_window then
-			documentation = setup_documentation_for_item(key, value)
-		else
-			documentation = nil
-		end
-		-- If eval_on_confirm is set to true,
-		-- use `value` instead of `key` upon completion
-		if opts.eval_on_confirm then
-			insertText = value
-		else
-			insertText = key
-		end
-
 		table.insert(completion_items, {
 			label = key,
-			insertText = insertText,
+			-- Evaluate the environment variable if `eval_on_confirm` is true
+			insertText = opts.eval_on_confirm and value or key,
 			word = key,
-			documentation = documentation,
+			-- Show documentation if `show_documentation_window` is true
+			documentation = opts.show_documentation_window and
+				setup_documentation_for_item(key, value),
 			kind = item_kind,
 		})
 	end

--- a/lua/cmp-env/complete.lua
+++ b/lua/cmp-env/complete.lua
@@ -19,15 +19,6 @@ local function setup_completion_items(params)
 	-- Get a dictionary with environment variables and their respective values
 	local env_vars = vim.fn.environ()
 
-	-- Set default item_kind as cmp.lsp.CompletionItemKind.Variable
-	local item_kind = cmp.lsp.CompletionItemKind.Variable
-
-	-- If item_kind option is set, use the value set
-	-- else use default value of cmp.lsp.CompletionItemKind.Variable
-	if opts.item_kind ~= item_kind then
-		item_kind = opts.item_kind
-	end
-
 	for key, value in pairs(env_vars) do
 		-- Prepend $ to key.
 		-- eg. PATH -> $PATH
@@ -41,7 +32,7 @@ local function setup_completion_items(params)
 			-- Show documentation if `show_documentation_window` is true
 			documentation = opts.show_documentation_window and
 				setup_documentation_for_item(key, value),
-			kind = item_kind,
+			kind = opts.item_kind,
 		})
 	end
 end


### PR DESCRIPTION
I found a way to get `show_documentation_window` and `eval_on_confirm` much more efficiently. This implementation does the exact same thing but in less lines of code.