### PR TITLE
Add an option to show braces around the variables

### DIFF
--- a/lua/cmp-env/complete.lua
+++ b/lua/cmp-env/complete.lua
@@ -20,9 +20,9 @@ local function setup_completion_items(params)
 	local env_vars = vim.fn.environ()
 
 	for key, value in pairs(env_vars) do
-		-- Prepend $ to key.
-		-- eg. PATH -> $PATH
-		key = "$" .. key
+		-- Prepend $ to key, also surround in braces if `show_braces` is true
+		-- e.g. PATH -> $PATH -> ${PATH}
+		key = "$" .. (opts.show_braces and "{" .. key .. "}" or key)
 
 		table.insert(completion_items, {
 			label = key,

--- a/lua/cmp-env/options.lua
+++ b/lua/cmp-env/options.lua
@@ -4,6 +4,7 @@ local M = {}
 
 M.default_options = {
 	eval_on_confirm = false,
+	show_braces = false,
 	show_documentation_window = true,
 	item_kind = cmp.lsp.CompletionItemKind.Variable,
 }
@@ -12,6 +13,7 @@ M.validate_options = function(params)
 	local options = vim.tbl_deep_extend("keep", params.option, M.default_options)
 	vim.validate({
 		eval_on_confirm = { options.eval_on_confirm, "boolean" },
+		show_braces = { options.show_braces, "boolean" },
 		show_documentation_window = { options.show_documentation_window, "boolean" },
 		item_kind = { options.item_kind, "number" },
 	})


### PR DESCRIPTION
Some people prefer to have braces around their environment variables. I simply added an option called `show_braces` and set the default to false.