### PR TITLE
Remove unnecessary function: `get_keyword_pattern`

### DIFF
--- a/lua/cmp-env/init.lua
+++ b/lua/cmp-env/init.lua
@@ -8,10 +8,6 @@ source.get_trigger_characters = function()
 	return { "$" }
 end
 
-source.get_keyword_pattern = function()
-	return "\\$[^[:blank:]]*"
-end
-
 source.complete = require("cmp-env.complete")
 
 return source


### PR DESCRIPTION
The default value for `get_keyword_pattern` does the exact same thing as the implementation in this plugin. It is unnecessary to have it.