### PR TITLE
Remove `get_trigger_characters` function

### DIFF
--- a/lua/cmp-env/init.lua
+++ b/lua/cmp-env/init.lua
@@ -4,10 +4,6 @@ source.new = function()
 	return setmetatable({}, { __index = source })
 end
 
-source.get_trigger_characters = function()
-	return { "$" }
-end
-
 source.get_keyword_pattern = function()
 	return "\\$[^[:blank:]]*"
 end


### PR DESCRIPTION
See #7 for an explanation as to why we do not need this function.